### PR TITLE
Update to get password from Get-PAOrder

### DIFF
--- a/Import-AcmeCertificateToKeyVault.ps1
+++ b/Import-AcmeCertificateToKeyVault.ps1
@@ -28,11 +28,10 @@ $pfxFilePath = Join-Path -Path $orderDirectoryPath -ChildPath "fullchain.pfx"
 # If we have a order and certificate available
 if ((Test-Path -Path $orderDirectoryPath) -and (Test-Path -Path $orderDataPath) -and (Test-Path -Path $pfxFilePath)) {
 
-    # Load order data
-    $orderData = Get-Content -Path $orderDataPath -Raw | ConvertFrom-Json
+    $pfxPass = (Get-PAOrder $certificateName).PfxPass
 
     # Load PFX
-    $certificate = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList $pfxFilePath, $orderData.PfxPass, 'EphemeralKeySet'
+    $certificate = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList $pfxFilePath, $pfxPass, 'EphemeralKeySet'
 
     # Get the current certificate from key vault (if any)
     $azureKeyVaultCertificateName = $certificateName.Replace(".", "-").Replace("!", "wildcard")
@@ -41,6 +40,6 @@ if ((Test-Path -Path $orderDirectoryPath) -and (Test-Path -Path $orderDataPath) 
 
     # If we have a different certificate, import it
     If (-not $azureKeyVaultCertificate -or $azureKeyVaultCertificate.Thumbprint -ne $certificate.Thumbprint) {
-        Import-AzKeyVaultCertificate -VaultName $keyVaultResource.Name -Name $azureKeyVaultCertificateName -FilePath $pfxFilePath -Password (ConvertTo-SecureString -String $orderData.PfxPass -AsPlainText -Force) | Out-Null
+        Import-AzKeyVaultCertificate -VaultName $keyVaultResource.Name -Name $azureKeyVaultCertificateName -FilePath $pfxFilePath -Password (ConvertTo-SecureString -String $pfxPass -AsPlainText -Force) | Out-Null
     }
 }


### PR DESCRIPTION
Update to get the certificate password from Get-PAOrder as it is no longer included in the JSON in 4.0.0 (as per https://github.com/rmbolger/Posh-ACME/issues/302#issuecomment-752716880)

Fixes #1