### PR TITLE
Remove pa sync folder to start with a clean state.

### DIFF
--- a/New-AcmeCertificate.ps1
+++ b/New-AcmeCertificate.ps1
@@ -13,6 +13,9 @@ $CertificateNamesArr = $CertificateNames.Replace(',',';') -split ';' | ForEach-O
 
 # Create working directory
 $workingDirectory = Join-Path -Path "." -ChildPath "pa"
+if (Test-Path $workingDirectory) {
+	Remove-Item $workingDirectory -Recurse
+}
 New-Item -Path $workingDirectory -ItemType Directory | Out-Null
 
 # Sync contents of storage container to working directory


### PR DESCRIPTION
Hi there,

I noticed that `New-Item` can throw errors when the "pa" folder already exists, which is counter-productive in a pipeline.

Additionally, if I remove files/folders from the BLOB container, a local pipeline agent might still have an old version and `azcopy sync` does not clean up files that aren't in the source directory anymore, so the pipeline agent can still have old files that will be synced back to the BLOB again.