### PR TITLE
Update azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ name: 0.0.$(Build.BuildId)
 
 # Linux based agent; all except the first step will also work on Windows
 queue:
-  name: Hosted Ubuntu 1604
+  name: Azure Pipelines
 
 # The scheduled trigger will be set in the Azure DevOps portal
 trigger: none


### PR DESCRIPTION
ubuntu 16 is deprecated on azure devops.

Ref: https://docs.microsoft.com/en-us/azure/devops/release-notes/2021/pipelines/sprint-193-update#updated-schedule-for-removal-of-ubuntu-1604-image-on-microsoft-hosted-agents